### PR TITLE
fix(#7): padding in navigation bar

### DIFF
--- a/src/app/components/Navbar.jsx
+++ b/src/app/components/Navbar.jsx
@@ -7,10 +7,9 @@ export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <nav className="bg-white shadow-md sticky top-0 z-50">
+    <nav className="bg-white shadow-md sticky top-0 z-50 px-4 mb-2">
       <div className=" ">
         <div className="flex justify-between h-16">
-          
           <div className="flex items-center">
             <Link href="/" className="text-xl font-bold text-indigo-600">
               MyLibrary


### PR DESCRIPTION
fixes #7 . 
Solve the navigation padding issue with adding 16 px left right padding and 8 px bottom margin . 
<img width="1242" height="160" alt="image" src="https://github.com/user-attachments/assets/b3abb3ee-ca25-4051-acd1-c4ae20d95fb4" />
