### PR TITLE
added chrome extension

### DIFF
--- a/chrome extension/manifest.json
+++ b/chrome extension/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "Component Library Quick Access",
+  "version": "1.0.0",
+  "description": "Instant access to an open-source Next.js + Tailwind CSS Component Library with ready-to-use UI components like Buttons and Cards.",
+  "permissions": ["tabs"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Component Library"
+  }
+}

--- a/chrome extension/popup.css
+++ b/chrome extension/popup.css
@@ -1,0 +1,60 @@
+body {
+  font-family: "Segoe UI", Arial, sans-serif;
+  width: 280px;
+  padding: 18px;
+  background: #1e1e2f; /* dark-mode developer vibe */
+  color: #f0f0f0;
+  text-align: center;
+  border-radius: 12px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.15);
+  transition: background 0.3s ease, transform 0.2s ease;
+}
+
+body:hover {
+  background: #2c2c44; /* subtle hover dark effect */
+}
+
+h2 {
+  font-size: 20px;
+  margin-bottom: 10px;
+  color: #4fc3f7; /* tech blue */
+  letter-spacing: 0.5px;
+}
+
+p {
+  font-size: 13px;
+  margin: 8px 0;
+  color: #cfcfcf;
+}
+
+button {
+  width: 100%;
+  padding: 12px;
+  background: linear-gradient(135deg, #42a5f5, #1e88e5);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+  margin-top: 12px;
+  box-shadow: 0 3px 10px rgba(30, 136, 229, 0.4);
+  transition: all 0.25s ease;
+}
+
+button:hover {
+  background: linear-gradient(135deg, #1e88e5, #1565c0);
+  transform: translateY(-2px) scale(1.03);
+  box-shadow: 0 6px 14px rgba(21, 101, 192, 0.45);
+}
+
+button:active {
+  transform: scale(0.98);
+}
+
+.hint {
+  font-size: 11px;
+  color: #aaa;
+  margin-top: 8px;
+  font-style: italic;
+}

--- a/chrome extension/popup.html
+++ b/chrome extension/popup.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Component Library</title>
+  <link rel="stylesheet" href="popup.css" />
+</head>
+<body>
+  <div id="container">
+    <h2>🧩 Component Library</h2>
+    <p>Open-source Next.js + Tailwind CSS UI components</p>
+
+    <button id="openApp">🚀 Open Library</button>
+    <p class="hint">Click to access ready-to-use components</p>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome extension/popup.js
+++ b/chrome extension/popup.js
@@ -1,0 +1,4 @@
+document.getElementById("openApp").addEventListener("click", () => {
+  chrome.tabs.create({ url: "https://component-library-omega-tawny.vercel.app/" });
+  
+});


### PR DESCRIPTION
fixes #59 
It adds a lightweight Chrome Extension that provides one-click access to the deployed Component Library site.

Changes made:

- Added manifest.json for the Chrome Extension.
- Added popup.html with a button to open the deployed site.
- Added popup.js to handle button click and open the site in a new tab.
- Added popup.css for styling the popup.


How to test:

1. Clone the repo and navigate to the extension folder.
2. Open Chrome → Extensions → Enable Developer Mode → Load Unpacked → Select the extension folder.
3.  Click the extension icon → popup appears → click “Open Library” → the deployed site opens in a new tab.