### PR TITLE
feat(feedback): add contact links (email, GitHub, Discord)

### DIFF
--- a/src/app/feedback/page.js
+++ b/src/app/feedback/page.js
@@ -227,18 +227,33 @@ export default function FeedbackPage() {
             {/* Contact Info */}
             <div className="bg-white rounded-lg shadow-sm border p-6">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">
-                Other Ways to Reach Us
+                    Other Ways to Reach Us
               </h3>
               <div className="space-y-3">
-                <OutlineButton className="w-full justify-center">
+                <a
+                  href="mailto:gps.96169@gmail.com"
+                  className="w-full inline-flex justify-center px-4 py-2 border border-gray-200 rounded-md text-sm font-medium text-theme-secondary hover:bg-gray-50"
+                >
                   📧 Email Support
-                </OutlineButton>
-                <OutlineButton className="w-full justify-center">
+                </a>
+
+                <a
+                  href="https://discord.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full inline-flex justify-center px-4 py-2 border border-gray-200 rounded-md text-sm font-medium text-theme-secondary hover:bg-gray-50"
+                >
                   💬 Discord Community
-                </OutlineButton>
-                <OutlineButton className="w-full justify-center">
+                </a>
+
+                <a
+                  href="https://github.com/Gyanthakur/component-library"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full inline-flex justify-center px-4 py-2 border border-gray-200 rounded-md text-sm font-medium text-theme-secondary hover:bg-gray-50"
+                >
                   🐙 GitHub Issues
-                </OutlineButton>
+                </a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Description
Add direct contact links to the Feedback page sidebar so users and contributors can easily reach the project.

Changes
- Updated src/app/feedback/page.js
  - Added mailto link (gps.96169@gmail.com)
  - Added GitHub repo link (https://github.com/Gyanthakur/component-library)
  - Added Discord link (https://discord.com/)

How to test
1. Checkout the branch locally and run the dev server: `npm run dev`
2. Open http://localhost:3000/feedback
3. In the sidebar "Other Ways to Reach Us", click:
   - Email (opens mail client)
   - GitHub (opens repo in new tab)
   - Discord (opens discord.com in new tab)

Before:
<img width="1920" height="1080" alt="Screenshot (77)" src="https://github.com/user-attachments/assets/c895719a-18fb-4c4f-84bb-bb53b51dd3a4" />

After:

https://github.com/user-attachments/assets/aedb9c4c-485b-42a1-b85d-a7950c1f84ce

