### PR TITLE
Fix: Dark Mode Hover Text Visibility Issue

### DIFF
--- a/src/app/feedback/page.js
+++ b/src/app/feedback/page.js
@@ -232,7 +232,7 @@ export default function FeedbackPage() {
               <div className="space-y-3">
                 <a
                   href="mailto:gps.96169@gmail.com"
-                  className="w-full inline-flex justify-center px-4 py-2 border border-gray-200 rounded-md text-sm font-medium text-theme-secondary hover:scale-106"
+                  className="w-full inline-flex justify-center px-4 py-2 border border-gray-200 rounded-md text-sm font-medium text-theme-secondary hover:bg-gray-50"
                 >
                   📧 Email Support
                 </a>
@@ -241,7 +241,7 @@ export default function FeedbackPage() {
                   href="https://discord.com/"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="w-full inline-flex justify-center px-4 py-2 border border-gray-200 rounded-md text-sm font-medium text-theme-secondary hover:scale-106"
+                  className="w-full inline-flex justify-center px-4 py-2 border border-gray-200 rounded-md text-sm font-medium text-theme-secondary hover:bg-gray-50"
                 >
                   💬 Discord Community
                 </a>
@@ -250,7 +250,7 @@ export default function FeedbackPage() {
                   href="https://github.com/Gyanthakur/component-library"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="w-full inline-flex justify-center px-4 py-2 border border-gray-200 rounded-md text-sm font-medium text-theme-secondary hover:scale-106"
+                  className="w-full inline-flex justify-center px-4 py-2 border border-gray-200 rounded-md text-sm font-medium text-theme-secondary hover:bg-gray-50"
                 >
                   🐙 GitHub Issues
                 </a>


### PR DESCRIPTION
## 📝 Description

This pull request addresses an issue where **text inside the Feedback page  becomes invisible or unreadable in dark mode when hovered or focused**.

The fix ensures that text remains visible and accessible in both light and dark themes by applying the same styling in 'Other ways to reach out ' buttons like other buttons.

Fixes #158 

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)

## Testing Steps

1. Switch the app to dark mode.

2. Navigate to /feedback.

3. Hover over and focus on the feedback other ways to reach out buttons.

4. Verify that:
- The text remains visible (white or light color).
- No contrast or accessibility issues occur.


## ✅ Checklist

- [ ] My code follows the project’s coding style and guidelines.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] I have updated the documentation if required.

---

## 📸 Screenshots (if applicable)

<img width="1440" height="900" alt="Screenshot 2025-10-19 at 12 33 31 PM" src="https://github.com/user-attachments/assets/64149f6d-5700-4fed-bb37-01ba91f84def" />


## 💬 Additional Comments

Now when user hover on Reach out buttons text colors remains same  so it looks good in dark mode also.